### PR TITLE
fix: corregir asignación de estado y validaciones en creación de herramienta

### DIFF
--- a/src/main/java/com/empresa/toolsapi/dto/tool/ToolRequestDTO.java
+++ b/src/main/java/com/empresa/toolsapi/dto/tool/ToolRequestDTO.java
@@ -3,6 +3,7 @@ package com.empresa.toolsapi.dto.tool;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.validator.constraints.URL;
@@ -11,7 +12,7 @@ import org.hibernate.validator.constraints.URL;
 @Setter
 public class ToolRequestDTO {
     @NotBlank(message = "El nombre es obligatorio")
-    @Max(100)
+    @Size(max = 100, message = "El nombre debe tener como máximo 100 caracteres")
     private String name;
     private String description;
     @NotBlank(message = "La URL de imagen no puede estar vacia")

--- a/src/main/java/com/empresa/toolsapi/entity/Tool.java
+++ b/src/main/java/com/empresa/toolsapi/entity/Tool.java
@@ -36,6 +36,7 @@ public class Tool {
 
     //Nuevo
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private ToolStatus status = ToolStatus.IN_STORE;
 
     @Column(name = "ticket_code", unique = true, nullable = false)

--- a/src/main/java/com/empresa/toolsapi/mapper/ToolMapper.java
+++ b/src/main/java/com/empresa/toolsapi/mapper/ToolMapper.java
@@ -7,6 +7,8 @@ import com.empresa.toolsapi.dto.tool.ToolResponseDTO;
 import com.empresa.toolsapi.entity.Category;
 import com.empresa.toolsapi.entity.Section;
 import com.empresa.toolsapi.entity.Tool;
+import com.empresa.toolsapi.enums.ToolStatus;
+import com.empresa.toolsapi.utils.AppSettings;
 
 public class ToolMapper {
 
@@ -18,6 +20,8 @@ public class ToolMapper {
                 .urlImg(dto.getUrlImg())
                 .section(section)
                 .category(category)
+                .status(ToolStatus.IN_STORE)
+                .ticketCode(AppSettings.NOT_TICKET)
                 .build();
     }
 


### PR DESCRIPTION
- Se asigna explícitamente ToolStatus.IN_STORE y ticketCode por defecto en el mapper para evitar null en BD.
- Se reemplazan anotaciones "Max" por "Size" en campos String para validar longitud correctamente.